### PR TITLE
Fix reconnect bar bug

### DIFF
--- a/components/global/reconnect_bar.js
+++ b/components/global/reconnect_bar.js
@@ -4,13 +4,13 @@ import styles from "../../styles/components/reconnect_bar/style";
 import { Text, Animated } from "react-native";
 
 export default function ReconnectBar() {
-    const { isConnected } = useWebSocket();
+    const { isConnected, shouldReconnect } = useWebSocket();
     const reconnectTimeout = useRef(null);
     const [visible, setVisible] = useState(false);
     const topValue = useRef(new Animated.Value(0)).current;
 
     useEffect(() => {
-        if (!isConnected) {
+        if (!isConnected && shouldReconnect.current) {
             reconnectTimeout.current = setTimeout(() => {
                 setVisible(true);
             }, 4000);

--- a/pages/account.js
+++ b/pages/account.js
@@ -7,6 +7,7 @@ import * as SecureStore from 'expo-secure-store';
 import { useWebSocket } from "../scripts/websocket_handler";
 import * as Notifications from "expo-notifications";
 import Constants from "expo-constants";
+import { useUserData } from "../scripts/user_data_provider";
 
 // Get values from secure store
 async function getValueFor(key) {
@@ -22,6 +23,7 @@ export function AccountPage({ navigation }) {
     const [username, setUsername] = useState("");
     const [userPronouns, setUserPronouns] = useState();
     const [userBio, setUserBio] = useState();
+    const { setUserData } = useUserData();
 
     async function get_auth_credentials() {
         const username_ = await getValueFor("username");
@@ -115,8 +117,12 @@ export function AccountPage({ navigation }) {
             })
         })
 
+        // Delete auth credentials from device
         await SecureStore.deleteItemAsync("username");
         await SecureStore.deleteItemAsync("token");
+
+        // Clear user data from user data provider
+        setUserData(null);
 
         navigation.replace("Login");
     }

--- a/scripts/websocket_handler.js
+++ b/scripts/websocket_handler.js
@@ -191,6 +191,7 @@ export const WebSocketProvider = ({ children }) => {
         sendMessage,
         closeConnection,
         updateTypingStatus,
+        shouldReconnect,
       }}
     >
       {children}


### PR DESCRIPTION
## Description
Fixed an issue where the reconnect bar would show up on the login screen.

## Related Issue
#101 

## Proposed Changes
An update was made to the reconnect bar to check if the `shouldReconnect` variable was true. If the WebSocket is disconnected and it should reconnect, it will show the reconnect bar.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.