### PR TITLE
Fix animation issue with pages

### DIFF
--- a/App.js
+++ b/App.js
@@ -92,12 +92,12 @@ export default function App() {
                 <Stack.Screen
                   name="Login"
                   component={LoginScreen}
-                  options={{ title: 'Login Page', animationEnabled: false }}
+                  options={{ title: 'Login Page', animation: 'none' }}
                 />
                 <Stack.Screen
                   name="Main"
                   component={MainScreen}
-                  options={{ title: 'Main Page', animationEnabled: false }}
+                  options={{ title: 'Main Page', animation: 'none' }}
                 />
                 <Stack.Screen
                   name="Messages"
@@ -110,7 +110,7 @@ export default function App() {
                 <Stack.Screen
                   name="Notifications"
                   component={Notifications}
-                  options={{ title: 'Notifications', animationEnabled: false }}
+                  options={{ title: 'Notifications', animation: 'none' }}
                 />
                 <Stack.Screen
                   name="Add Friend"
@@ -126,7 +126,7 @@ export default function App() {
                 <Stack.Screen
                   name="Account"
                   component={AccountPage}
-                  options={{ title: 'Account', animationEnabled: false}}
+                  options={{ title: 'Account', animation: 'none' }}
                 />
                 <Stack.Screen
                   name='User Profile'


### PR DESCRIPTION
## Description
Fixed an issue with pages playing the change animation despite it being disabled in the stack screen.

## Related Issue
#124 

## Proposed Changes
The fix was to replace `animationEnabled: false` with `animation: 'none'` in the pages options.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
