### PR TITLE
Fix issue with account creation modal

### DIFF
--- a/pages/create_account.js
+++ b/pages/create_account.js
@@ -17,7 +17,7 @@ export default function CreateAccountScreen({ navigation }) {
 
     return (
         <WebView
-            source={{ uri: 'http://localhost:3000/create_account' }}
+            source={{ uri: 'https://my.lifplatforms.com/create_account' }}
             userAgent='RingerMobileWebView'
             onMessage={handle_message}
         />


### PR DESCRIPTION
## Description
Fixed an issue with the account creation modal not loading the account creation page.

## Related Issue
#135 

## Proposed Changes
Changed the URL from `http://localhost:3000/create_account` to `https://my.lifplatforms.com/create_account`.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
