### PR TITLE
Fix caching bug

### DIFF
--- a/app/(app)/conversations/[conversation_id].js
+++ b/app/(app)/conversations/[conversation_id].js
@@ -90,7 +90,7 @@ export default function MessagesPage() {
             if (cachedMessages) {
                 setConversationData(cachedMessages.conversationName, conversation_id);
                 setMessages(cachedMessages.messages);
-                //setIsLoading(false); // TEMP: pls uncomment
+                setIsLoading(false);
             } else {
                 setShowLoader(true);
             }


### PR DESCRIPTION
## Description
Fixed a bug wher ringer would not show the cache data and display a blank chat log until the server data loaded.

## Related Issue
#156 

## Proposed Changes
Just had to uncoment one line of code that updated the loading state after the cache data was loaded in.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
