### PR TITLE
Fix messages page scrolling issue

### DIFF
--- a/app/(app)/conversations/[conversation_id].js
+++ b/app/(app)/conversations/[conversation_id].js
@@ -69,6 +69,16 @@ export default function MessagesPage() {
     }
 
     useEffect(() => {
+        function scroll_to_bottom() {
+            if (!keepScrollPosition) {
+                setTimeout(() => {
+                    if (scrollViewRef.current) {
+                        scrollViewRef.current.scrollToEnd({ animated: false });
+                    }
+                }, 100);
+            }
+        }
+
         async function load_messages() {
             // Set loading state
             setIsLoading(true);
@@ -79,6 +89,7 @@ export default function MessagesPage() {
                 setConversationData(cachedMessages.conversationName, conversation_id);
                 setMessages(cachedMessages.messages);
                 setIsLoading(false);
+                scroll_to_bottom();
             } else {
                 setShowLoader(true);
             }
@@ -123,12 +134,7 @@ export default function MessagesPage() {
                 setUnreadMessages(conversation_id, data.Unread_Messages || 0);
 
                 // Scroll to end of conversation
-                // Set timeout to ensure messages load before scrolling
-                setTimeout(() => {
-                    if (scrollViewRef.current) {
-                        scrollViewRef.current.scrollToEnd({ animated: false });
-                    }
-                }, 1);
+                scroll_to_bottom();
 
                 // Add messages to cache
                 addMessagesCache(conversation_id, conversationName, messages);


### PR DESCRIPTION
## Description
Fixed an issue with scrolling on the messages page. Basically, if the messages in the conversation were loaded from the server, Ringer would not scroll to the bottom of the conversation until the server fetch completes.

## Related Issue
#170 

## Proposed Changes
The scroll functionality was moved into an independent function that is called both when the cache messages are loaded and when the server fetch completes.

## Checklist
- [x] I have tested the changes locally.
- [x] I have updated the documentation (if necessary).
- [x] I have reviewed the code for any potential issues.
